### PR TITLE
Add cache module based on infinispan

### DIFF
--- a/cache/pom.xml
+++ b/cache/pom.xml
@@ -9,27 +9,45 @@
         <version>0.13.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>auditquery-model-java</artifactId>
-
-    <name>Audit Query Model Java</name>
+    <name>Audit Query Cache</name>
+    <artifactId>auditquery-cache</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+        </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>org.commonjava.propulsor.content-audit</groupId>
+            <artifactId>propulsor-content-audit-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.commonjava.auditquery</groupId>
+            <artifactId>auditquery-model-java</artifactId>
+        </dependency>
+
+        <!-- Infinispan -->
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cdi-embedded</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-query</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-query-dsl</artifactId>
         </dependency>
 
         <dependency>
@@ -41,5 +59,4 @@
             <artifactId>hibernate-search-engine</artifactId>
         </dependency>
     </dependencies>
-
 </project>

--- a/cache/src/main/java/org/commonjava/auditquery/cache/AuditQueryCacheProducer.java
+++ b/cache/src/main/java/org/commonjava/auditquery/cache/AuditQueryCacheProducer.java
@@ -1,0 +1,70 @@
+package org.commonjava.auditquery.cache;
+
+import org.commonjava.auditquery.tracking.TrackingSummary;
+import org.commonjava.auditquery.tracking.dto.TrackedContentDTO;
+import org.commonjava.propulsor.content.audit.model.FileEvent;
+import org.hibernate.search.annotations.Factory;
+import org.hibernate.search.annotations.Resolution;
+import org.hibernate.search.cfg.SearchMapping;
+import org.infinispan.Cache;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import java.lang.annotation.ElementType;
+
+@ApplicationScoped
+public class AuditQueryCacheProducer
+{
+
+    private static final String TRACKING_SUMMARY_CACHE = "tracking_summary_cache";
+
+    private static final String FILE_EVENT_CACHE = "file_event_cache";
+
+    private static final String TRACKED_CONTENT_DTO_CACHE = "tracked_content_dto_cache";
+
+    @Inject
+    CacheProducer cacheProvider;
+
+    @Factory
+    public SearchMapping getSearchMapping()
+    {
+        final SearchMapping entryMapping = new SearchMapping();
+        entryMapping.entity( FileEvent.class )
+                    .indexed()
+                    .property( "sessionId", ElementType.METHOD )
+                    .field()
+                    .property( "eventType", ElementType.METHOD )
+                    .field()
+                    .property( "checksum", ElementType.METHOD )
+                    .field()
+                    .property( "timestamp", ElementType.METHOD )
+                    .dateBridge( Resolution.MILLISECOND )
+                    .field()
+                    .property( "extra", ElementType.METHOD )
+                    .field();
+
+        return entryMapping;
+    }
+
+    @Produces
+    @TrackingSummaryCache
+    public Cache<String, TrackingSummary> createTrackingSummaryCache()
+    {
+        return cacheProvider.getCache( TRACKING_SUMMARY_CACHE );
+    }
+
+    @Produces
+    @FileEventsCache
+    public Cache<String, FileEvent> createFileEventCache()
+    {
+        return cacheProvider.getCache( FILE_EVENT_CACHE );
+    }
+
+    @Produces
+    @TrackedContentDTOCache
+    public Cache<String, TrackedContentDTO> createTrackedContentDTOCache()
+    {
+        return cacheProvider.getCache( TRACKED_CONTENT_DTO_CACHE );
+    }
+}

--- a/cache/src/main/java/org/commonjava/auditquery/cache/CacheProducer.java
+++ b/cache/src/main/java/org/commonjava/auditquery/cache/CacheProducer.java
@@ -1,0 +1,35 @@
+package org.commonjava.auditquery.cache;
+
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * This is a temporary implementation and it will be replaced by the one in propulsor
+ */
+@ApplicationScoped
+public class CacheProducer
+{
+
+    EmbeddedCacheManager cacheManager;
+
+    public CacheProducer()
+    {
+
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        cacheManager = new DefaultCacheManager();
+    }
+
+    public <K, V> Cache<K, V> getCache(String name)
+    {
+        return cacheManager.getCache( name );
+    }
+
+}

--- a/cache/src/main/java/org/commonjava/auditquery/cache/FileEventsCache.java
+++ b/cache/src/main/java/org/commonjava/auditquery/cache/FileEventsCache.java
@@ -1,0 +1,19 @@
+package org.commonjava.auditquery.cache;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier used to supply file events cache in infinispan.xml.
+ */
+@Qualifier
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface FileEventsCache
+{
+}

--- a/cache/src/main/java/org/commonjava/auditquery/cache/TrackedContentDTOCache.java
+++ b/cache/src/main/java/org/commonjava/auditquery/cache/TrackedContentDTOCache.java
@@ -1,0 +1,16 @@
+package org.commonjava.auditquery.cache;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface TrackedContentDTOCache
+{
+}

--- a/cache/src/main/java/org/commonjava/auditquery/cache/TrackingSummaryCache.java
+++ b/cache/src/main/java/org/commonjava/auditquery/cache/TrackingSummaryCache.java
@@ -1,0 +1,19 @@
+package org.commonjava.auditquery.cache;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier used to supply tracking summary cache in infinispan.xml.
+ */
+@Qualifier
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface TrackingSummaryCache
+{
+}

--- a/cache/src/main/resources/infinispan.xml
+++ b/cache/src/main/resources/infinispan.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:infinispan:config:8.2 http://www.infinispan.org/schemas/infinispan-config-8.2.xsd"
+        xmlns="urn:infinispan:config:8.2">
+
+    <cache-container default-cache="default">
+        <!-- template configurations -->
+        <local-cache-configuration name="local-template">
+        </local-cache-configuration>
+        
+        <local-cache name="tracking_summary_cache" configuration="local-template">
+            <eviction strategy="LRU" size="20000" type="COUNT" />
+            <indexing index="LOCAL">
+                <property name="default.directory_provider">ram</property>
+            </indexing>
+        </local-cache>
+
+        <local-cache name="tracked_content_dto_cache" configuration="local-template">
+            <eviction strategy="LRU" size="20000" type="COUNT" />
+            <indexing index="LOCAL">
+                <property name="default.directory_provider">ram</property>
+            </indexing>
+        </local-cache>
+
+        <local-cache name="file_event_cache" configuration="local-template">
+            <eviction strategy="LRU" size="40000" type="COUNT" />
+            <indexing index="LOCAL">
+                <property name="default.directory_provider">ram</property>
+                <property name="hibernate.search.model_mapping">org.commonjava.auditquery.cache.AuditQueryCacheProducer</property>
+            </indexing>
+        </local-cache>
+    </cache-container>
+
+</infinispan>

--- a/model-java/src/main/java/org/commonjava/auditquery/tracking/TrackingSummary.java
+++ b/model-java/src/main/java/org/commonjava/auditquery/tracking/TrackingSummary.java
@@ -1,10 +1,15 @@
 package org.commonjava.auditquery.tracking;
 
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
 import java.util.Date;
 import java.util.Set;
 
+@Indexed
 public class TrackingSummary
 {
+    @Field
     private String trackingID;
 
     /* checksums */

--- a/model-java/src/main/java/org/commonjava/auditquery/tracking/dto/TrackedContentDTO.java
+++ b/model-java/src/main/java/org/commonjava/auditquery/tracking/dto/TrackedContentDTO.java
@@ -1,9 +1,14 @@
 package org.commonjava.auditquery.tracking.dto;
 
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
 import java.util.Set;
 
+@Indexed
 public class TrackedContentDTO
 {
+    @Field
     private String trackingID;
 
     private Set<TrackedContentEntryDTO> uploads;

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
     <weftVersion>1.4.1</weftVersion>
     <slf4jVersion>1.7.25</slf4jVersion>
     <jackson-version>2.9.7</jackson-version>
+    <infinispanVersion>8.2.4.Final</infinispanVersion>
+    <hibernateVersion>5.8.1.Final</hibernateVersion>
   </properties>
 
   <modules>
@@ -36,6 +38,7 @@
     <module>model-java</module>
     <module>core</module>
     <module>uis</module>
+    <module>cache</module>
   </modules>
 
   <dependencyManagement>
@@ -72,6 +75,11 @@
         <artifactId>propulsor-configuration-dotconf</artifactId>
         <version>${propulsorVersion}</version>
       </dependency>
+      <dependency>
+        <groupId>org.commonjava.propulsor.content-audit</groupId>
+        <artifactId>propulsor-content-audit-api</artifactId>
+        <version>${propulsorVersion}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.commonjava.cdi.util</groupId>
@@ -92,6 +100,11 @@
       <dependency>
         <groupId>org.commonjava.auditquery</groupId>
         <artifactId>auditquery-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.auditquery</groupId>
+        <artifactId>auditquery-cache</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -137,6 +150,36 @@
         <version>${slf4jVersion}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-cdi-embedded</artifactId>
+        <version>${infinispanVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-core</artifactId>
+        <version>${infinispanVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-query</artifactId>
+        <version>${infinispanVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-query-dsl</artifactId>
+        <version>${infinispanVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-search-orm</artifactId>
+        <version>${hibernateVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-search-engine</artifactId>
+        <version>${hibernateVersion}</version>
+      </dependency>
 
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
 The CacheProducer of this patch is a simple(temp) one that will be replaced with the one in propulsor, currently the cache producer is in Indy project and will be moved into propulsor later. 