### PR TITLE
Add timestamps to TrackedContentEntryDTO, and upgrade parent pom

### DIFF
--- a/model-java/src/main/java/org/commonjava/auditquery/tracking/dto/TrackedContentEntryDTO.java
+++ b/model-java/src/main/java/org/commonjava/auditquery/tracking/dto/TrackedContentEntryDTO.java
@@ -19,11 +19,12 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Set;
 
 public class TrackedContentEntryDTO implements Comparable<TrackedContentEntryDTO>, Externalizable
 {
 
-    private static final int VERSION = 1;
+    private static final int VERSION = 2;
 
     /* current artifact repository key info */
     private String storeKey;
@@ -47,6 +48,8 @@ public class TrackedContentEntryDTO implements Comparable<TrackedContentEntryDTO
     private String sha1;
 
     private Long size;
+
+    private Set<Long> timestamps;
 
     public TrackedContentEntryDTO()
     {
@@ -125,6 +128,7 @@ public class TrackedContentEntryDTO implements Comparable<TrackedContentEntryDTO
         out.writeObject( sha256 );
         out.writeObject( sha1 );
         out.writeObject( size );
+        out.writeObject( timestamps );
     }
 
     @Override
@@ -145,5 +149,25 @@ public class TrackedContentEntryDTO implements Comparable<TrackedContentEntryDTO
         sha256 = (String)in.readObject();
         sha1 = (String)in.readObject();
         size = (Long)in.readObject();
+
+        if ( version > 1 )
+        {
+            timestamps = (Set<Long>) in.readObject();
+        }
+    }
+
+    public Set<Long> getTimestamps()
+    {
+        return timestamps;
+    }
+
+    public void setTimestamps( final Set<Long> timestamps )
+    {
+        this.timestamps = timestamps;
+    }
+
+    public void merge( final TrackedContentEntryDTO from )
+    {
+        this.timestamps.addAll( from.getTimestamps() );
     }
 }

--- a/model-java/src/main/java/org/commonjava/auditquery/tracking/dto/TrackedContentEntryDTO.java
+++ b/model-java/src/main/java/org/commonjava/auditquery/tracking/dto/TrackedContentEntryDTO.java
@@ -19,6 +19,8 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 public class TrackedContentEntryDTO implements Comparable<TrackedContentEntryDTO>, Externalizable
@@ -61,6 +63,7 @@ public class TrackedContentEntryDTO implements Comparable<TrackedContentEntryDTO
         this.storeKey = storeKey;
         this.accessChannel = accessChannel;
         this.path = path;
+        this.timestamps = new HashSet<>( Collections.singleton( System.currentTimeMillis() ) );
     }
 
     public String getStoreKey() { return storeKey; }

--- a/model-java/src/test/java/org/commonjava/auditquery/tracking/TrackedContentEntryDTOTest.java
+++ b/model-java/src/test/java/org/commonjava/auditquery/tracking/TrackedContentEntryDTOTest.java
@@ -18,6 +18,8 @@ package org.commonjava.auditquery.tracking;
 import org.commonjava.auditquery.tracking.dto.TrackedContentEntryDTO;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static junit.framework.Assert.assertEquals;
 
 public class TrackedContentEntryDTOTest extends AuditQueryModelTest
@@ -35,6 +37,7 @@ public class TrackedContentEntryDTOTest extends AuditQueryModelTest
         output.setSha256( "f8e5dacc1982c045a48b93e09e9b0beb6c820981dfaf5cf1578ac8806ea0e036" );
         output.setLocalUrl( "http://local.com/org/jboss/test/test-01.pom" );
         output.setOriginUrl( "http://remote.com/org/jboss/test/test-01.pom" );
+        output.setTimestamps( Collections.singleton( System.currentTimeMillis() ) );
 
         TrackedContentEntryDTO input = read( output );
 
@@ -46,6 +49,7 @@ public class TrackedContentEntryDTOTest extends AuditQueryModelTest
         assertEquals(input.getSha1(), output.getSha1());
         assertEquals(input.getSha256(), output.getSha256());
         assertEquals(input.getStoreKey(), output.getStoreKey());
+        assertEquals( input.getTimestamps(), output.getTimestamps() );
 
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava</groupId>
     <artifactId>commonjava</artifactId>
-    <version>13</version>
+    <version>16</version>
   </parent>
 
   <groupId>org.commonjava.auditquery</groupId>


### PR DESCRIPTION
Adding timestamps will improve our ability to simulate builders for performance testing. We'll be able to generate a "script" of content downloads and uploads using these timestamps and the URLs associated with each entry, then simply pass over the script, pausing between access time offsets, and performing the appropriate download / upload for each at the appropriate time.